### PR TITLE
emoji ligatures should use "ccmp" rather than "liga"

### DIFF
--- a/layerize.js
+++ b/layerize.js
@@ -648,8 +648,11 @@ function generateTTX() {
     defaultLangSys.ele("ReqFeatureIndex", {value: 65535});
     defaultLangSys.ele("FeatureIndex", {index: 0, value: 0});
 
+    // The ligature rules are assigned to the "ccmp" feature (*not* "liga"),
+    // as they should not be disabled in contexts such as letter-spacing or
+    // inter-character justification, where "normal" ligatures are turned off.
     var featureRecord = GSUB.ele("FeatureList").ele("FeatureRecord", {index: 0});
-    featureRecord.ele("FeatureTag", {value: "liga"});
+    featureRecord.ele("FeatureTag", {value: "ccmp"});
     featureRecord.ele("Feature").ele("LookupListIndex", {index: 0, value: 0});
 
     var lookup = GSUB.ele("LookupList").ele("Lookup", {index: 0});


### PR DESCRIPTION
Currently, if letter-spacing is applied in Firefox, the emoji ligatures such as regional-indicator flags or family groups will decompose, because Firefox automatically disables standard ligature features when letter-spacing (or inter-character justification) is in effect.

But unlike an "fi" ligature, we don't want 🇸🇪 or 👩‍👩‍👧‍👧 to split into its components just because letter-spacing is used. So the glyph composition feature "ccmp" is a better choice than "liga" for the OpenType rules here.