### PR TITLE
Add python-fontforge to the Ubuntu install example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Both FontForge and font-tools can be installed via `homebrew` on OS X, or packag
     brew install fonttools fontforge
 
     # Ubuntu, for example
-    sudo apt-get install fonttools fontforge
+    sudo apt-get install fonttools fontforge python-fontforge
 
 ## Building the font
 


### PR DESCRIPTION
Fixes #35.

Not sure if it's worth calling out in the prose as well or not.
I'm also assuming the python part comes as part of it on homebrew?  Or has it changed there?