### PR TITLE
Make comparison tests more reliable by bypassing caching

### DIFF
--- a/tests/index.css
+++ b/tests/index.css
@@ -1,16 +1,12 @@
-@font-face {
-  font-family: "Twemoji Mozilla";
-  src: url('../build/Twemoji Mozilla.ttf') format('truetype');
-  font-weight: normal;
-  font-style: normal;
-}
-
 body {
   font-family: sans-serif;
 }
 
-.emoji {
-  font-family: "Twemoji Mozilla";
+body.font-loaded .emoji,
+body.font-loaded canvas,
+body.font-loaded img,
+body.font-loaded .dom-ref {
+  font-family: "Twemoji Mozilla Built";
 }
 
 h1 form {
@@ -68,7 +64,6 @@ p.failed {
 
 canvas, img, .dom-ref {
   display: inline-block;
-  font-family: "Twemoji Mozilla";
   font-size: 180px;
   line-height: 180px;
   vertical-align: middle;


### PR DESCRIPTION
Several times while using the comparison tests I mistakenly thought a change I
made had broken something or not worked because the tests were re-using cached
copies (or the browser's shipped copy) because I hadn't hard-refreshed the page
instead of just normal refreshing.
These changes avoid such surprises.

- Refer to the font as "Twemoji Mozilla Built" instead so there's no chance of
  using the browser's inbuilt copy.
- Load the font dynamically using the FontFace API to enable varying the query
  string.
- Add a timestamp to the URLs for the font and SVG files, so the browser won't
  load cached copies.