### PR TITLE
Update to Twemoji 13.1.0 (Emoji 13.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twemoji-colr",
   "description": "Twemoji font in COLR/CPAL layered format.",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "author": "Jonathan Kew <jfkthame@gmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/mozilla/twemoji-colr#readme",
   "devDependencies": {
     "emojibase-data": "^6.2.0",
-    "resemblejs": "^2.10.0"
+    "resemblejs": "^4.0.0"
   },
   "scripts": {
     "grunt": "grunt"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "homepage": "https://github.com/mozilla/twemoji-colr#readme",
   "devDependencies": {
-    "emojibase-data": "^4.2.1",
+    "emojibase-data": "^6.2.0",
     "resemblejs": "^2.10.0"
   },
   "scripts": {

--- a/twe-svg.zip.version.txt
+++ b/twe-svg.zip.version.txt
@@ -1,1 +1,1 @@
-Zipped copy of the assets/svg directory from https://github.com/twitter/twemoji/archive/v12.1.6.zip
+Zipped copy of the assets/svg directory from https://github.com/twitter/twemoji/archive/v13.1.0.zip


### PR DESCRIPTION
Twemoji 13.1.0 and above bring support for the new sequences from Emoji 13.1. (Fixes #58 and #54.)

Similar to the build issues reported in #51 and #52, I had to use Node.js `v10.24.1`. I also had to update to a new major release of `resemblejs` to get a successful `npm install`.

Here is the final build output (`Twemoji Mozilla.ttf` + `Twemoji Mozilla.ttx`): [build-0.6.0.zip](https://github.com/mozilla/twemoji-colr/files/6765201/build-0.6.0.zip)

(Personally, I didn't have to replace `unzip` by `unzipper`. Nevertheless, this might be a good idea in the future.)
