### PR TITLE
Replace unzip dependency with unzipper

### DIFF
--- a/layerize.js
+++ b/layerize.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
     rmdir = require('rmdir'),
-    unzip = require('unzip'),
+    unzip = require('unzipper'),
     xmlbuilder = require('xmlbuilder'),
     xml2js = require('xml2js');
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-webfonts": "^4.0.2",
     "load-grunt-tasks": "^5.1.0",
     "rmdir": "^1.2.0",
-    "unzip": "^0.1.11",
+    "unzipper": "^0.10.14",
     "xml2js": "^0.4.23",
     "xmlbuilder": "^15.1.1"
   },


### PR DESCRIPTION
Fixes https://github.com/mozilla/twemoji-colr/issues/68

The `unzip` dependency has not been maintained for several years and it stopped working. I replaced it with another package `unzipper`, which declares the following:
>This is an active fork and drop-in replacement of the `node-unzip`.