### PR TITLE
Update deps for modern Node.js versions

### DIFF
--- a/layerize.js
+++ b/layerize.js
@@ -1,6 +1,5 @@
 var fs = require('fs'),
-    rmdir = require('rmdir'),
-    unzip = require('unzip'),
+    unzip = require('unzipper'),
     xmlbuilder = require('xmlbuilder'),
     xml2js = require('xml2js');
 
@@ -718,7 +717,7 @@ function generateTTX() {
 }
 
 // Delete and re-create target directory, to remove any pre-existing junk
-rmdir(targetDir, function () {
+fs.rm(targetDir, {recursive:true,force:true}, function () {
     fs.mkdirSync(targetDir);
     fs.mkdirSync(targetDir + "/glyphs");
     fs.mkdirSync(targetDir + "/colorGlyphs");

--- a/package.json
+++ b/package.json
@@ -21,11 +21,10 @@
   "dependencies": {
     "grunt": "^1.4.1",
     "grunt-cli": "^1.4.3",
-    "grunt-webfonts": "^4.0.2",
+    "grunt-webfonts": "^5.0.0",
     "load-grunt-tasks": "^5.1.0",
-    "rmdir": "^1.2.0",
-    "unzip": "^0.1.11",
-    "xml2js": "^0.4.23",
+    "unzipper": "^0.10.14",
+    "xml2js": "^0.6.2",
     "xmlbuilder": "^15.1.1"
   },
   "keywords": [
@@ -41,8 +40,5 @@
   },
   "scripts": {
     "grunt": "grunt"
-  },
-  "resolutions": {
-    "graceful-fs": "^4.2.9"
   }
 }


### PR DESCRIPTION
### About

This PR updates all dependencies to the latest version, replaces `unzip` with `unzipper` (unlike to #69 I've also removed the `resolutions`, I believe those are no longer needed to be specified) and replaces the use of `rmdir` with Node's `fs.rm( /*(...)*/, {recursive:true, force:true}, /*(...)*/)`. Outside of fixing the build for modern Node.js builds, this also resolves all vulnerability warnings in `npm audit`).

It should also be pointed out that since I've updated some libraries, there might be no support for older Node versions (which I suppose is fine, I believe the oldest version functional should be Node 14 and I find that as a quite old version as well).

### Changelog (took from commit description)

- Replace `unzip` package with `unzipper`.
- Remove `rmdir` package (literally ~~once-liner~~ one-liner in Node API can replace [it], maybe in the past it was useful but now it's literally junk library).
- Overall update dependencies to the latest version available (except devDependencies for now).